### PR TITLE
Bump LÖVE version to 11.3

### DIFF
--- a/loadconf.lua
+++ b/loadconf.lua
@@ -263,9 +263,9 @@ loadconf.default_opts = {
 	include_defaults = false
 }
 
---- The current stable love version, which right now is "11.2". Please
+--- The current stable love version, which right now is "11.3". Please
 --  submit an issue/pull request if this is out of date, sorry~
-loadconf.stable_love = "11.2"
+loadconf.stable_love = "11.3"
 
 --- A table containing the default config tables for each version of love.
 --  @usage assert(loadconf.defaults["0.9.2"].window.fullscreentype == "normal")
@@ -282,10 +282,10 @@ local function defaults_copy(old_v, version)
 end
 
 -- default values for 11.X {{{
-loadconf.defaults["11.2"] = {
+loadconf.defaults["11.3"] = {
 	identity = nil,
 	appendidentity = false,
-	version = "11.2",
+	version = "11.3",
 	console = false,
 	accelerometerjoystick = true,
 	externalstorage = false,
@@ -332,8 +332,9 @@ loadconf.defaults["11.2"] = {
 		window        = true
 	}
 }
-defaults_copy("11.2", "11.1")
-defaults_copy("11.2", "11.0")
+defaults_copy("11.3", "11.2")
+defaults_copy("11.3", "11.1")
+defaults_copy("11.3", "11.0")
 -- }}}
 
 -- default values for 0.10.X {{{


### PR DESCRIPTION
LÖVE 11.3 has been out for quite some time.
This PR is sadly incomplete, because a few fields have been added to the configuration, but it’s better than nothing for now.