### PR TITLE
Love 11.5 is now stable

### DIFF
--- a/loadconf.lua
+++ b/loadconf.lua
@@ -265,7 +265,7 @@ loadconf.default_opts = {
 
 --- The current stable love version, which right now is "11.3". Please
 --  submit an issue/pull request if this is out of date, sorry~
-loadconf.stable_love = "11.3"
+loadconf.stable_love = "11.5"
 
 --- A table containing the default config tables for each version of love.
 --  @usage assert(loadconf.defaults["0.9.2"].window.fullscreentype == "normal")
@@ -282,10 +282,10 @@ local function defaults_copy(old_v, version)
 end
 
 -- default values for 11.X {{{
-loadconf.defaults["11.3"] = {
+loadconf.defaults["11.5"] = {
 	identity = nil,
 	appendidentity = false,
-	version = "11.3",
+	version = "11.5",
 	console = false,
 	accelerometerjoystick = true,
 	externalstorage = false,
@@ -336,6 +336,8 @@ loadconf.defaults["11.3"] = {
 		window        = true
 	}
 }
+defaults_copy("11.5", "11.4")
+defaults_copy("11.4", "11.3")
 defaults_copy("11.3", "11.2")
 loadconf.defaults["11.2"].audio.mic = nil
 loadconf.defaults["11.2"].window.usedpiscale = nil

--- a/rockspecs/loadconf-0.3.7-1.rockspec
+++ b/rockspecs/loadconf-0.3.7-1.rockspec
@@ -1,0 +1,19 @@
+package = "loadconf"
+version = "0.3.7-1"
+source = {
+   url = "git://github.com/Alloyed/loadconf",
+   tag = "v0.3.7",
+}
+description = {
+   homepage = "https://github.com/Alloyed/loadconf",
+   license = "MIT"
+}
+dependencies = {
+   "lua >= 5.1, < 5.5"
+}
+build = {
+   type = "builtin",
+   modules = {
+      loadconf = "loadconf.lua"
+   }
+}


### PR DESCRIPTION
The currently released version of Love on their website is 11.5. This just updates the stable version and the defaults to match <https://love2d.org/wiki/Config_Files>, which are the same as 11.3. I also went ahead and created a rockspec, assuming that's helpful.